### PR TITLE
Dockerfile and some fixes for ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go get -u github.com/kardianos/govendor \
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o /main
 
-FROM scratch
+FROM alpine
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update \
  && apk add git curl \
  && apk add ca-certificates
 
-RUN adduser -D -g '' user
+RUN adduser --uid 10000 -D -g '' user
 
 COPY . $GOPATH/src/github.com/tomaszkiewicz/docker-copy-docker-image
 WORKDIR $GOPATH/src/github.com/tomaszkiewicz/docker-copy-docker-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:alpine as builder
+
+RUN apk update \
+ && apk add git curl \
+ && apk add ca-certificates
+
+RUN adduser -D -g '' user
+
+COPY . $GOPATH/src/github.com/tomaszkiewicz/docker-copy-docker-image
+WORKDIR $GOPATH/src/github.com/tomaszkiewicz/docker-copy-docker-image
+
+RUN go get -u github.com/kardianos/govendor \
+ && export GO_VERSION=$(go version | cut -d' ' -f3 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+') \
+ && govendor sync
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o /main
+
+FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+
+COPY --from=builder /main /main
+
+USER user
+ENTRYPOINT ["/main"]

--- a/main.go
+++ b/main.go
@@ -237,7 +237,13 @@ func main() {
 		}
 	}
 
-	err = destHub.PutManifest(*destArgs.Repository, *destArgs.Tag, manifest)
+	destManifest := &schema1.SignedManifest{
+		Manifest: manifest.Manifest,
+	}
+
+	destManifest.Manifest.Name = *destArgs.Repository
+
+	err = destHub.PutManifest(*destArgs.Repository, *destArgs.Tag, destManifest)
 	if err != nil {
 		fmt.Printf("Failed to upload manifest to %s/%s:%s. %v", destHub.URL, *destArgs.Repository, *destArgs.Tag, err)
 		exitCode = -1


### PR DESCRIPTION
Hi, 

As I've promised I'm opening a pull request with the rest of my changes, I mean:
1. I've added Dockerfile to build a project into docker image
2. I've changed the logic of parsing repo name - instead of depending on some prefix, now we use full url, that contains region - it is very useful to do that this way, because we have unified way of addressing and also we don't have to have any ~/.aws/config in place to set a region (which is a kind of trouble in docker scenarios)
3. Fixed manifest for destination - ECR requires to set manifest name to be the same as repository name.

The change number 2 is not backward compatible.

I understand that you can reject this PR to be backward compatible and it's ok :)

Best regards

Łukasz Tomaszkiewicz